### PR TITLE
chore: point github repository to `yarnpkg/pnp-rs` in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "BSD-2-Clause"
 description = "Resolution primitives for Yarn PnP"
 homepage = "https://yarnpkg.com"
-repository = "https://github.com/yarnpkg/berry/"
+repository = "https://github.com/yarnpkg/pnp-rs"
 
 [dependencies]
 arca = "0.1.3"


### PR DESCRIPTION
This makes it easier to navigate to this repository on crates.io and docs.rs