### PR TITLE
feat: ✨ allow file type to be called with unslashed dir path

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -293,6 +293,39 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_zip_type_api() {
+        let zip = open_zip_via_read(&PathBuf::from(
+            "data/@babel-plugin-syntax-dynamic-import-npm-7.8.3-fb9ff5634a-8.zip",
+        ))
+        .unwrap();
+
+        assert_eq!(zip.file_type("node_modules").unwrap(), FileType::Directory);
+        assert_eq!(zip.file_type("node_modules/").unwrap(), FileType::Directory);
+    }
+
+    #[test]
+    #[should_panic(expected = "Kind(NotFound)")]
+    fn test_zip_type_api_not_exist_dir_with_slash() {
+        let zip = open_zip_via_read(&PathBuf::from(
+            "data/@babel-plugin-syntax-dynamic-import-npm-7.8.3-fb9ff5634a-8.zip",
+        ))
+        .unwrap();
+
+        zip.file_type("not_exists/").unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Kind(NotFound)")]
+    fn test_zip_type_api_not_exist_dir_without_slash() {
+        let zip = open_zip_via_read(&PathBuf::from(
+            "data/@babel-plugin-syntax-dynamic-import-npm-7.8.3-fb9ff5634a-8.zip",
+        ))
+        .unwrap();
+
+        zip.file_type("not_exists").unwrap();
+    }
+
+    #[test]
     fn test_zip_list() {
         let zip = open_zip_via_read(&PathBuf::from("data/@babel-plugin-syntax-dynamic-import-npm-7.8.3-fb9ff5634a-8.zip"))
             .unwrap();

--- a/src/zip.rs
+++ b/src/zip.rs
@@ -55,12 +55,20 @@ where T : AsRef<[u8]> {
     }
 
     pub fn file_type(&self, p: &str) -> Result<FileType, std::io::Error> {
-        if self.dirs.contains(p) {
+        if self.is_dir(p) {
             Ok(FileType::Directory)
         } else if self.files.contains_key(p) {
             Ok(FileType::File)
         } else {
             Err(std::io::Error::from(std::io::ErrorKind::NotFound))
+        }
+    }
+
+    fn is_dir(&self, p: &str) -> bool {
+        if p.ends_with('/') {
+            self.dirs.contains(p)
+        } else {
+            self.dirs.contains(&format!("{}/", p))
         }
     }
 


### PR DESCRIPTION
## before

`zip.file_type("node_modules")`   returns  Error `NotFound`
`zip.file_type("node_modules/")`  returns `Directory`

## after

`zip.file_type("node_modules")`   returns `Directory`
`zip.file_type("node_modules/")`  returns `Directory`

## background

try to resolve `./devtools`  from `preact-xxxxxx.zip/node_modules/preact` 

`zip.file_type("node_modules/preact/devtools")` returns NotFound, results in  rspack-resolve failed.

