### PR TITLE
fix: specifier subpath parse error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,7 +518,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pnp"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "arca",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pnp"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2021"
 license = "BSD-2-Clause"
 description = "Resolution primitives for Yarn PnP"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,15 @@ pub fn parse_bare_identifier(specifier: &str) -> Result<(String, Option<String>)
     }
 
     if let Some(ident) = ident_option {
-        Ok((ident, segments.next().map(|v| v.to_string())))
+        let lefts = segments.collect::<Vec<_>>();
+
+        let subpath = if lefts.len() == 0 {
+            None
+        } else {
+            Some(lefts.join("/"))
+        };
+
+        Ok((ident, subpath))
     } else {
         Err(Error::BadSpecifier {
             message: String::from("Invalid specifier"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,12 +183,12 @@ pub fn parse_bare_identifier(specifier: &str) -> Result<(String, Option<String>)
     }
 
     if let Some(ident) = ident_option {
-        let lefts = segments.collect::<Vec<_>>();
+        let rests = segments.collect::<Vec<_>>();
 
-        let subpath = if lefts.len() == 0 {
+        let subpath = if rests.len() == 0 {
             None
         } else {
-            Some(lefts.join("/"))
+            Some(rests.join("/"))
         };
 
         Ok((ident, subpath))


### PR DESCRIPTION
this case was found by https://github.com/web-infra-dev/rspack/issues/10127

```txt
  × Module not found: Can't resolve 'webpack/hot/emitter.js' in '/Users/bytedance/git/problem/pnp-repro/.yarn/__virtual__/webpack-dev-server-virtual-e3e5db5beb/0/cache/webpack-dev-server-npm-5.2.0-baf75bbb61-87b7acc194.zip/node_modules/webpack-dev-server/client'
    ╭─[46:23]
 44 │ /* global __resourceQuery, __webpack_hash__ */ /// <reference types="webpack/module" />
 45 │ import webpackHotLog from "webpack/hot/log.js";
 46 │ import hotEmitter from "webpack/hot/emitter.js";
    ·                        ────────────────────────
 47 │ import socket from "./socket.js";
 48 │ import { formatProblem, createOverlay } from "./overlay.js";
    ╰────
```
## root cause

calling `parse_bare_identifier` with `webpack/hot/emitter.js`
expect returns `("webpack", Some("hot/emitterjs"))`
actual returns `("webpack", Some("hot"))`


