### PR TITLE
Makes the build smaller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,7 +532,6 @@ dependencies = [
  "path-slash",
  "pathdiff",
  "radix_trie",
- "regex",
  "rstest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ arca = "^0.7"
 byteorder = "1"
 clean-path = "0.2.1"
 concurrent_lru = "^0.2"
-fancy-regex = "^0.13.0"
+fancy-regex = { version = "^0.13.0", default-features = false }
 indexmap = { version = "2.7.1", features = ["serde"] }
 lazy_static = "1"
 miniz_oxide = "^0.7"
@@ -20,7 +20,6 @@ mmap-rs = { version = "^0.6", optional = true }
 path-slash = "0.2.1"
 pathdiff = "^0.2"
 radix_trie = "0.2.1"
-regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_with = {  version = "3", features = ["indexmap_2"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,7 +238,7 @@ pub fn load_pnp_manifest<P: AsRef<Path>>(p: P) -> Result<Manifest, Error> {
         })?;
 
     lazy_static! {
-        static ref RE: Regex = Regex::new("(const\\s+RAW_RUNTIME_STATE\\s*=\\s*|hydrateRuntimeState\\(JSON\\.parse\\()'").unwrap();
+        static ref RE: Regex = Regex::new("(const[ \\n]+RAW_RUNTIME_STATE[ \\n]*=[ \\n]*|hydrateRuntimeState\\(JSON\\.parse\\()'").unwrap();
     }
 
     let manifest_match = RE.find(&manifest_content)


### PR DESCRIPTION
The `regex` crate is making the library fairly large. Since we also use `fancy_regex`, having `regex` feels redundant. We only need it for its ability to operate over slices rather than just str, but with some refactoring of the `vpath` function I managed to avoid it entirely, making it possible to remove the dependency.

Along with disabling unicode support for `fancy_regex`, we get a ~1,7MiB binary (-1MiB). The remaining report shows that `fancy_regex` is now the main overhead, but unfortunately I don't see a good way to fix it without removing support for [`pnpIgnorePattern`](https://yarnpkg.com/configuration/yarnrc#pnpIgnorePatterns) (which is stored as a regex inside the JSON payload):

```
 File  .text     Size Crate
18.4%  33.9% 313.2KiB std
15.4%  28.4% 262.5KiB regex_automata
 9.8%  18.1% 167.0KiB regex_syntax
 6.0%  11.0% 101.8KiB pnp
 3.4%   6.3%  58.3KiB fancy_regex
 0.8%   1.4%  12.9KiB serde_json
 0.2%   0.4%   3.9KiB serde
 0.2%   0.3%   2.8KiB [Unknown]
 0.2%   0.3%   2.7KiB ryu
 0.1%   0.2%   2.0KiB smallvec
 0.1%   0.2%   2.0KiB hashbrown
 0.1%   0.1%   1.3KiB pathdiff
 0.1%   0.1%   1.3KiB radix_trie
 0.0%   0.1%     792B clean_path
 0.0%   0.0%      20B __rustc
 0.0%   0.0%      12B path_slash
54.3% 100.0% 924.3KiB .text section size, the file size is 1.7MiB
```

Ref https://github.com/unrs/unrs-resolver/issues/166