### PR TITLE
chore(Cargo.toml): reduce binary size by removing unicode from regex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ arca = "^0.7"
 byteorder = "1"
 clean-path = "0.2.1"
 concurrent_lru = "^0.2"
-fancy-regex = "^0.13.0"
+fancy-regex = { version = "^0.13.0", default-features = false, features = ["std"] }
 indexmap = { version = "2.7.1", features = ["serde"] }
 lazy_static = "1"
 miniz_oxide = "^0.7"
@@ -20,7 +20,7 @@ mmap-rs = { version = "^0.6", optional = true }
 path-slash = "0.2.1"
 pathdiff = "^0.2"
 radix_trie = "0.2.1"
-regex = "1"
+regex = { version = "1", default-features = false, features = ["std"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_with = {  version = "3", features = ["indexmap_2"] }


### PR DESCRIPTION
This should be safe because because our usages of regexes do not have unicode patterns.

This reduces binary size of `oxc-resolver` from 2.2M to 1.6M.