### PR TITLE
refactor: remove indexmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,7 +197,6 @@ checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
- "serde",
 ]
 
 [[package]]
@@ -322,7 +321,6 @@ dependencies = [
  "clean-path",
  "concurrent_lru",
  "fancy-regex",
- "indexmap",
  "miniz_oxide",
  "mmap-rs",
  "path-slash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ byteorder = "1"
 clean-path = "0.2.1"
 concurrent_lru = "^0.2"
 fancy-regex = { version = "^0.14.0", default-features = false, features = ["std"] }
-indexmap = { version = "2", default-features = true, features = ["serde"] }
 miniz_oxide = "^0.8"
 mmap-rs = { version = "^0.6", optional = true }
 path-slash = "0.2.1"

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,7 +1,6 @@
-use std::{hash::BuildHasherDefault, path::PathBuf};
+use std::path::PathBuf;
 
-use indexmap::IndexMap;
-use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
+use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, de::Deserializer};
 
 use crate::util::{RegexDef, Trie};
@@ -49,8 +48,7 @@ pub struct Manifest {
     //   }]
     // ]
     #[serde(deserialize_with = "deserialize_package_registry_data")]
-    pub package_registry_data:
-        FxHashMap<String, IndexMap<String, PackageInformation, BuildHasherDefault<FxHasher>>>,
+    pub package_registry_data: FxHashMap<String, FxHashMap<String, PackageInformation>>,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Deserialize)]
@@ -110,13 +108,9 @@ where
     Ok(map)
 }
 
-#[expect(clippy::type_complexity)]
 fn deserialize_package_registry_data<'de, D>(
     deserializer: D,
-) -> Result<
-    FxHashMap<String, IndexMap<String, PackageInformation, BuildHasherDefault<FxHasher>>>,
-    D::Error,
->
+) -> Result<FxHashMap<String, FxHashMap<String, PackageInformation>>, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -126,7 +120,7 @@ where
     let mut map = FxHashMap::default();
     for item in Vec::<Item>::deserialize(deserializer)? {
         let key = item.0.unwrap_or_else(|| "".to_string());
-        let value = IndexMap::from_iter(
+        let value = FxHashMap::from_iter(
             item.1.into_iter().map(|(k, v)| (k.unwrap_or_else(|| "".to_string()), v)),
         );
         map.insert(key, value);


### PR DESCRIPTION
The only call site that iterates through the indexmap doesn't seem to require the map to be in the order of declaration.

https://github.com/yarnpkg/pnp-rs/blob/b443744d7ec6a4523782ca24f04063121445b49c/src/lib.rs#L160-L175