### PR TITLE
Improves performances

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   bench:
     runs-on: ubuntu-latest
+    permissions: 
+      pull-requests: write
     steps:
       - uses: taiki-e/checkout-action@v1
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -301,10 +301,7 @@ fn vpath(p: &Path) -> std::io::Result<VPath> {
             base_path.insert(0, '/');
         }
 
-        return Ok(VPath::Virtual(VirtualInfo {
-            base_path,
-            virtual_segments,
-        }));
+        return Ok(VPath::Virtual(VirtualInfo { base_path, virtual_segments }));
     }
 
     Ok(VPath::Native(PathBuf::from(normalized_path)))


### PR DESCRIPTION
- The original code was computing the `join` call even when the path didn't use either `__virtual__` or `.zip`.
- Vectors were allocated empty. I updated that to preallocate a small arbitrary amount of items.