### PR TITLE
refactor: clean up duplicated code

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -4,6 +4,7 @@ use std::{
     str::Utf8Error,
 };
 
+use crate::util::is_drive_prefix;
 use crate::zip::Zip;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -193,11 +194,6 @@ where
     }
 }
 
-fn is_portable_drive_root(segment: &str) -> bool {
-    let bytes = segment.as_bytes();
-    bytes.len() == 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
-}
-
 fn base_path_from_items(
     base_items: &[&str],
     normalized_path: &str,
@@ -212,7 +208,7 @@ fn base_path_from_items(
 
     if cfg!(windows)
         && base_items.len() == 1
-        && base_items.first().is_some_and(|segment| is_portable_drive_root(segment))
+        && base_items.first().is_some_and(|segment| is_drive_prefix(segment))
     {
         base_path.push('/');
     }
@@ -268,7 +264,7 @@ fn vpath(p: &Path) -> std::io::Result<VPath> {
                 // We extract the backward segments from the base ones
                 if let Ok(depth) = depth {
                     let has_drive_root =
-                        base_items.first().is_some_and(|segment| is_portable_drive_root(segment));
+                        base_items.first().is_some_and(|segment| is_drive_prefix(segment));
                     let min_root_len = usize::from(
                         has_drive_root
                             && (normalized_relative_path != normalized_path || cfg!(windows)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,10 @@ fn parse_global_package_name(specifier: &str) -> Option<(String, Option<String>)
     Some((package_name, subpath))
 }
 
+fn via_suffix(ident: &str, specifier: &str) -> String {
+    if ident != specifier { format!(" (via \"{specifier}\")") } else { String::new() }
+}
+
 pub fn parse_bare_identifier(specifier: &str) -> Result<(String, Option<String>), Error> {
     let name = if specifier.starts_with('@') {
         parse_scoped_package_name(specifier)
@@ -277,11 +281,7 @@ pub fn resolve_to_unqualified_via_manifest(
                     format!(
                         "Your application tried to access {dependency_name}. While this module is usually interpreted as a Node builtin, your resolver is running inside a non-Node resolution context where such builtins are ignored. Since {dependency_name} isn't otherwise declared in your dependencies, this makes the require call ambiguous and unsound.\n\nRequired package: {dependency_name}{via}\nRequired by: ${issuer_path}",
                         dependency_name = &ident,
-                        via = if ident != specifier {
-                            format!(" (via \"{specifier}\")")
-                        } else {
-                            String::new()
-                        },
+                        via = via_suffix(&ident, specifier),
                         issuer_path = parent.to_string_lossy(),
                     )
                 } else {
@@ -289,11 +289,7 @@ pub fn resolve_to_unqualified_via_manifest(
                         "${issuer_locator_name} tried to access {dependency_name}. While this module is usually interpreted as a Node builtin, your resolver is running inside a non-Node resolution context where such builtins are ignored. Since {dependency_name} isn't otherwise declared in ${issuer_locator_name}'s dependencies, this makes the require call ambiguous and unsound.\n\nRequired package: {dependency_name}{via}\nRequired by: ${issuer_path}",
                         issuer_locator_name = &parent_locator.name,
                         dependency_name = &ident,
-                        via = if ident != specifier {
-                            format!(" (via \"{specifier}\")")
-                        } else {
-                            String::new()
-                        },
+                        via = via_suffix(&ident, specifier),
                         issuer_path = parent.to_string_lossy(),
                     )
                 }
@@ -301,11 +297,7 @@ pub fn resolve_to_unqualified_via_manifest(
                 format!(
                     "Your application tried to access {dependency_name}, but it isn't declared in your dependencies; this makes the require call ambiguous and unsound.\n\nRequired package: {dependency_name}{via}\nRequired by: {issuer_path}",
                     dependency_name = &ident,
-                    via = if ident != specifier {
-                        format!(" (via \"{}\")", &specifier)
-                    } else {
-                        String::from("")
-                    },
+                    via = via_suffix(&ident, specifier),
                     issuer_path = parent.to_string_lossy(),
                 )
             } else {
@@ -314,11 +306,7 @@ pub fn resolve_to_unqualified_via_manifest(
                     issuer_locator_name = &parent_locator.name,
                     issuer_locator_reference = &parent_locator.reference,
                     dependency_name = &ident,
-                    via = if ident != specifier {
-                        format!(" (via \"{}\")", &specifier)
-                    } else {
-                        String::from("")
-                    },
+                    via = via_suffix(&ident, specifier),
                     issuer_path = parent.to_string_lossy(),
                 )
             };
@@ -350,11 +338,7 @@ pub fn resolve_to_unqualified_via_manifest(
                 format!(
                     "Your application tried to access {dependency_name} (a peer dependency); this isn't allowed as there is no ancestor to satisfy the requirement. Use a devDependency if needed.\n\nRequired package: {dependency_name}{via}\nRequired by: {issuer_path}",
                     dependency_name = &ident,
-                    via = if ident != specifier {
-                        format!(" (via \"{}\")", &specifier)
-                    } else {
-                        String::from("")
-                    },
+                    via = via_suffix(&ident, specifier),
                     issuer_path = parent.to_string_lossy(),
                 )
             } else if !broken_ancestors.is_empty()
@@ -365,11 +349,7 @@ pub fn resolve_to_unqualified_via_manifest(
                     issuer_locator_name = &parent_locator.name,
                     issuer_locator_reference = &parent_locator.reference,
                     dependency_name = &ident,
-                    via = if ident != specifier {
-                        format!(" (via \"{}\")", &specifier)
-                    } else {
-                        String::from("")
-                    },
+                    via = via_suffix(&ident, specifier),
                     issuer_path = parent.to_string_lossy(),
                 )
             } else {
@@ -378,11 +358,7 @@ pub fn resolve_to_unqualified_via_manifest(
                     issuer_locator_name = &parent_locator.name,
                     issuer_locator_reference = &parent_locator.reference,
                     dependency_name = &ident,
-                    via = if ident != specifier {
-                        format!(" (via \"{}\")", &specifier)
-                    } else {
-                        String::from("")
-                    },
+                    via = via_suffix(&ident, specifier),
                     issuer_path = parent.to_string_lossy(),
                 )
             };

--- a/src/util.rs
+++ b/src/util.rs
@@ -85,14 +85,9 @@ fn to_portable_path<'a>(str: &'a str) -> Cow<'a, str> {
     Cow::Borrowed(str)
 }
 
-#[cfg(windows)]
-fn is_drive_prefix(s: &str) -> bool {
+pub(crate) fn is_drive_prefix(s: &str) -> bool {
     let b = s.as_bytes();
     b.len() == 2 && b[0].is_ascii_alphabetic() && b[1] == b':'
-}
-#[cfg(not(windows))]
-fn is_drive_prefix(_: &str) -> bool {
-    false
 }
 
 pub fn normalize_path<P: AsRef<str>>(original: P) -> String {
@@ -106,12 +101,13 @@ pub fn normalize_path<P: AsRef<str>>(original: P) -> String {
     // A leading drive prefix (`C:`, `D:`, …) is treated as part of the root,
     // so `..` overshoot can't pop the drive letter and leave a rootless path
     // that downstream consumers misread as drive-relative. See #9.
-    let mut drive: Option<&str> = if rooted && components.peek().is_some_and(|c| is_drive_prefix(c))
-    {
-        components.next()
-    } else {
-        None
-    };
+    // Only gated on Windows: on Unix, segments like `C:` are ordinary names.
+    let mut drive: Option<&str> =
+        if cfg!(windows) && rooted && components.peek().is_some_and(|c| is_drive_prefix(c)) {
+            components.next()
+        } else {
+            None
+        };
 
     let mut out: Vec<&str> = Vec::new();
     for comp in components {

--- a/src/zip.rs
+++ b/src/zip.rs
@@ -97,16 +97,10 @@ where
     pub fn read_to_string(&self, p: &str) -> Result<String, std::io::Error> {
         let data = self.read(p)?;
 
-        Ok(io_bytes_to_str(data.as_slice())?.to_string())
+        String::from_utf8(data).map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::InvalidData, "File did not contain valid UTF-8")
+        })
     }
-}
-
-fn io_bytes_to_str(vec: &[u8]) -> Result<&str, std::io::Error> {
-    std::str::from_utf8(vec).map_err(|_| make_io_utf8_error())
-}
-
-fn make_io_utf8_error() -> std::io::Error {
-    std::io::Error::new(std::io::ErrorKind::InvalidData, "File did not contain valid UTF-8")
 }
 
 pub fn list_zip_entries(data: &[u8]) -> Result<FxHashMap<String, Option<Entry>>, Box<dyn Error>> {


### PR DESCRIPTION
## Summary

- Collapse `is_drive_prefix` (util.rs) and the byte-identical `is_portable_drive_root` (fs.rs) into one shared `pub(crate)` helper in `util.rs`. The Windows-only behavior in `normalize_path` is now gated at the call site via `cfg!(windows) &&` instead of with two `#[cfg]`-mirrored functions.
- Extract a `via_suffix(ident, specifier)` helper in `lib.rs` to replace the 6 repeated `if ident != specifier { format!(" (via \"…\")") } else { String::new() }` blocks inside `resolve_to_unqualified_via_manifest`.
- Inline the trivial single-use `io_bytes_to_str` / `make_io_utf8_error` helpers in `zip.rs`. `read_to_string` now uses `String::from_utf8` directly, which also avoids a `&str → String` clone.

Net: −33 lines, no behavior change.