### PR TITLE
Fix loose mode fallback resolution

### DIFF
--- a/data/loose_mode_fallback_manifest.json
+++ b/data/loose_mode_fallback_manifest.json
@@ -3,18 +3,28 @@
   "enableTopLevelFallback": true,
   "ignorePatternData": null,
   "fallbackExclusionList": [],
-  "fallbackPool": [["dep", "npm:0.11.0"]],
+  "fallbackPool": [
+    ["dep", "npm:0.11.0"],
+    ["null-fallback", null],
+    ["pool-resolved", ["dep", "npm:0.11.0"]]
+  ],
   "packageRegistryData": [
     [null, [
       [null, {
         "packageLocation": "./",
-        "packageDependencies": [["dep", "npm:1.4.0"]]
+        "packageDependencies": [
+          ["dep", "npm:1.4.0"],
+          ["pool-resolved", null]
+        ]
       }]
     ]],
     ["issuer", [
       ["npm:1.0.0", {
         "packageLocation": "./cache/issuer/",
-        "packageDependencies": []
+        "packageDependencies": [
+          ["unfulfilled-no-fallback", null],
+          ["pool-resolved", null]
+        ]
       }]
     ]],
     ["dep", [

--- a/data/loose_mode_fallback_manifest.json
+++ b/data/loose_mode_fallback_manifest.json
@@ -1,0 +1,31 @@
+{
+  "dependencyTreeRoots": [],
+  "enableTopLevelFallback": true,
+  "ignorePatternData": null,
+  "fallbackExclusionList": [],
+  "fallbackPool": [["dep", "npm:0.11.0"]],
+  "packageRegistryData": [
+    [null, [
+      [null, {
+        "packageLocation": "./",
+        "packageDependencies": [["dep", "npm:1.4.0"]]
+      }]
+    ]],
+    ["issuer", [
+      ["npm:1.0.0", {
+        "packageLocation": "./cache/issuer/",
+        "packageDependencies": []
+      }]
+    ]],
+    ["dep", [
+      ["npm:1.4.0", {
+        "packageLocation": "./cache/dep-1.4.0/",
+        "packageDependencies": []
+      }],
+      ["npm:0.11.0", {
+        "packageLocation": "./cache/dep-0.11.0/",
+        "packageDependencies": []
+      }]
+    ]]
+  ]
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,23 +240,46 @@ fn try_get_package<'a>(
         .and_then(|references| references.get(&locator.reference))
 }
 
+enum DependencyResolution {
+    Undeclared,
+    UnfulfilledPeer,
+    Resolved(PackageDependency),
+}
+
+impl DependencyResolution {
+    fn from_manifest_entry(entry: Option<&Option<PackageDependency>>) -> Self {
+        match entry {
+            None => Self::Undeclared,
+            Some(None) => Self::UnfulfilledPeer,
+            Some(Some(binding)) => Self::Resolved(binding.clone()),
+        }
+    }
+}
+
 /// Resolves `ident` via the top-level fallback locator first (matching the
 /// reference runtime), only deferring to the deduplicated `fallbackPool` when
-/// the top-level package doesn't declare it. The nested `Option` distinguishes
-/// "no pool entry" from a `null` pool binding.
-fn resolve_via_fallback(manifest: &Manifest, ident: &str) -> Option<Option<PackageDependency>> {
+/// the top-level package doesn't provide a concrete binding. Null fallback
+/// entries are ignored, matching the reference runtime.
+fn resolve_via_fallback(manifest: &Manifest, ident: &str) -> DependencyResolution {
     // The top-level locator (`{name: null, reference: null}`) is stored with
     // empty string keys after deserialization.
     let top_level_locator = PackageLocator { name: String::new(), reference: String::new() };
 
     if let Some(top_level_pkg) = try_get_package(manifest, &top_level_locator) {
-        // `Some(None)` marks an unfulfilled peer; skip it and defer to the pool.
-        if let Some(Some(binding)) = top_level_pkg.package_dependencies.get(ident) {
-            return Some(Some(binding.clone()));
+        // An unfulfilled peer doesn't provide a binding; defer to the pool.
+        if let DependencyResolution::Resolved(binding) =
+            DependencyResolution::from_manifest_entry(top_level_pkg.package_dependencies.get(ident))
+        {
+            return DependencyResolution::Resolved(binding);
         }
     }
 
-    manifest.fallback_pool.get(ident).cloned()
+    match DependencyResolution::from_manifest_entry(manifest.fallback_pool.get(ident)) {
+        DependencyResolution::Resolved(binding) => DependencyResolution::Resolved(binding),
+        DependencyResolution::Undeclared | DependencyResolution::UnfulfilledPeer => {
+            DependencyResolution::Undeclared
+        }
+    }
 }
 
 pub fn is_excluded_from_fallback(manifest: &Manifest, locator: &PackageLocator) -> bool {
@@ -283,32 +306,27 @@ pub fn resolve_to_unqualified_via_manifest(
     if let Some(parent_locator) = find_locator(manifest, parent) {
         let parent_pkg = get_package(manifest, parent_locator)?;
 
-        let mut reference_or_alias: Option<PackageDependency> = None;
-        let mut is_set = false;
-
-        if !is_set {
-            if let Some(Some(binding)) = parent_pkg.package_dependencies.get(&ident) {
-                reference_or_alias = Some(binding.clone());
-                is_set = true;
-            }
-        }
+        let mut dependency_resolution =
+            DependencyResolution::from_manifest_entry(parent_pkg.package_dependencies.get(&ident));
 
         // The top-level package itself never uses fallbacks (matching the
         // reference runtime's `issuerLocator.name !== null` guard).
-        if !is_set
-            && !parent_locator.name.is_empty()
+        if matches!(
+            &dependency_resolution,
+            DependencyResolution::Undeclared | DependencyResolution::UnfulfilledPeer
+        ) && !parent_locator.name.is_empty()
             && manifest.enable_top_level_fallback
             && !is_excluded_from_fallback(manifest, parent_locator)
         {
             // Prefer the top-level fallback locator over the deduplicated pool
             // so duplicated deps match what Node's PnP loader resolves to.
-            if let Some(fallback_resolution) = resolve_via_fallback(manifest, &ident) {
-                reference_or_alias = fallback_resolution;
-                is_set = true;
+            if let DependencyResolution::Resolved(binding) = resolve_via_fallback(manifest, &ident)
+            {
+                dependency_resolution = DependencyResolution::Resolved(binding);
             }
         }
 
-        if !is_set {
+        if matches!(&dependency_resolution, DependencyResolution::Undeclared) {
             let message = if nodejs_built_in_modules::is_nodejs_builtin_module(specifier) {
                 if is_dependency_tree_root(manifest, parent_locator) {
                     format!(
@@ -352,6 +370,14 @@ pub fn resolve_to_unqualified_via_manifest(
                 issuer_path: parent.to_path_buf(),
             })));
         }
+
+        let reference_or_alias = match dependency_resolution {
+            DependencyResolution::Undeclared => {
+                unreachable!("undeclared dependencies return an error above")
+            }
+            DependencyResolution::Resolved(resolution) => Some(resolution),
+            DependencyResolution::UnfulfilledPeer => None,
+        };
 
         if let Some(resolution) = reference_or_alias {
             let dependency_pkg = match resolution {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,6 +230,35 @@ pub fn get_package<'a>(
     Ok(info)
 }
 
+fn try_get_package<'a>(
+    manifest: &'a Manifest,
+    locator: &PackageLocator,
+) -> Option<&'a PackageInformation> {
+    manifest
+        .package_registry_data
+        .get(&locator.name)
+        .and_then(|references| references.get(&locator.reference))
+}
+
+/// Resolves `ident` via the top-level fallback locator first (matching the
+/// reference runtime), only deferring to the deduplicated `fallbackPool` when
+/// the top-level package doesn't declare it. The nested `Option` distinguishes
+/// "no pool entry" from a `null` pool binding.
+fn resolve_via_fallback(manifest: &Manifest, ident: &str) -> Option<Option<PackageDependency>> {
+    // The top-level locator (`{name: null, reference: null}`) is stored with
+    // empty string keys after deserialization.
+    let top_level_locator = PackageLocator { name: String::new(), reference: String::new() };
+
+    if let Some(top_level_pkg) = try_get_package(manifest, &top_level_locator) {
+        // `Some(None)` marks an unfulfilled peer; skip it and defer to the pool.
+        if let Some(Some(binding)) = top_level_pkg.package_dependencies.get(ident) {
+            return Some(Some(binding.clone()));
+        }
+    }
+
+    manifest.fallback_pool.get(ident).cloned()
+}
+
 pub fn is_excluded_from_fallback(manifest: &Manifest, locator: &PackageLocator) -> bool {
     manifest
         .fallback_exclusion_list
@@ -264,12 +293,17 @@ pub fn resolve_to_unqualified_via_manifest(
             }
         }
 
+        // The top-level package itself never uses fallbacks (matching the
+        // reference runtime's `issuerLocator.name !== null` guard).
         if !is_set
+            && !parent_locator.name.is_empty()
             && manifest.enable_top_level_fallback
             && !is_excluded_from_fallback(manifest, parent_locator)
         {
-            if let Some(fallback_resolution) = manifest.fallback_pool.get(&ident) {
-                reference_or_alias = fallback_resolution.clone();
+            // Prefer the top-level fallback locator over the deduplicated pool
+            // so duplicated deps match what Node's PnP loader resolves to.
+            if let Some(fallback_resolution) = resolve_via_fallback(manifest, &ident) {
+                reference_or_alias = fallback_resolution;
                 is_set = true;
             }
         }

--- a/src/lib_tests.rs
+++ b/src/lib_tests.rs
@@ -24,7 +24,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        ResolutionConfig, ResolutionHost, init_pnp_manifest, load_pnp_manifest,
+        Error, ResolutionConfig, ResolutionHost, init_pnp_manifest, load_pnp_manifest,
         parse_bare_identifier, resolve_to_unqualified, resolve_to_unqualified_via_manifest, util,
     };
 
@@ -167,6 +167,32 @@ mod tests {
                 );
             }
             other => panic!("Expected a resolved path, got: {other:?}"),
+        }
+
+        for dependency in ["undeclared", "null-fallback"] {
+            let resolution = resolve_to_unqualified_via_manifest(&manifest, dependency, &issuer);
+            match resolution {
+                Err(Error::UndeclaredDependency(_)) => {}
+                other => panic!("expected {dependency} to be undeclared, got {other:?}"),
+            }
+        }
+
+        let resolution =
+            resolve_to_unqualified_via_manifest(&manifest, "unfulfilled-no-fallback", &issuer);
+        match resolution {
+            Err(Error::MissingPeerDependency(_)) => {}
+            other => panic!("expected an unfulfilled peer error, got {other:?}"),
+        }
+
+        let resolution =
+            resolve_to_unqualified_via_manifest(&manifest, "pool-resolved", &issuer).unwrap();
+        match resolution {
+            Resolution::Resolved(path, _) => assert!(
+                path.to_string_lossy().contains("dep-0.11.0"),
+                "expected the pool alias to resolve, got {}",
+                path.display()
+            ),
+            other => panic!("expected the pool alias to resolve, got {other:?}"),
         }
     }
 

--- a/src/lib_tests.rs
+++ b/src/lib_tests.rs
@@ -139,6 +139,37 @@ mod tests {
         }
     }
 
+    /// Regression test for the loose-mode fallback bug:
+    /// `issuer` imports `dep` without declaring it, so it should resolve
+    /// to the top-level `dep@1.4.0`, not the `fallbackPool`'s `dep@0.11.0`.
+    #[test]
+    fn test_loose_mode_fallback_prefers_top_level_locator() {
+        let manifest_path =
+            std::env::current_dir().unwrap().join("data/loose_mode_fallback_manifest.json");
+        let mut manifest =
+            serde_json::from_str::<Manifest>(&fs::read_to_string(&manifest_path).unwrap()).unwrap();
+        init_pnp_manifest(&mut manifest, &manifest_path);
+
+        // `issuer` doesn't declare `dep`, triggering the loose-mode fallback.
+        let issuer = manifest_path.parent().unwrap().join("cache/issuer/index.js");
+        let resolution = resolve_to_unqualified_via_manifest(&manifest, "dep", &issuer).unwrap();
+
+        match resolution {
+            Resolution::Resolved(path, _) => {
+                let path = path.to_string_lossy();
+                assert!(
+                    path.contains("dep-1.4.0"),
+                    "expected fallback to resolve to the top-level version dep@1.4.0, got: {path}"
+                );
+                assert!(
+                    !path.contains("dep-0.11.0"),
+                    "fallback must not resolve to the fallback-pool copy dep@0.11.0, got: {path}"
+                );
+            }
+            other => panic!("Expected a resolved path, got: {other:?}"),
+        }
+    }
+
     #[test]
     fn test_parse_single_package_name() {
         let parsed = parse_bare_identifier("pkg");


### PR DESCRIPTION
## Summary

- match the Yarn reference PnP runtime by resolving loose-mode fallbacks from the top-level locator before the deduplicated fallback pool
- avoid applying fallback resolution when the issuer is the top-level package itself
- preserve undeclared and unfulfilled-peer states while evaluating fallbacks

Closes #111